### PR TITLE
Add missing backtick in "Developing Styled Components"

### DIFF
--- a/docs/developing-styled-components.md
+++ b/docs/developing-styled-components.md
@@ -1053,7 +1053,7 @@ export default PrimaryButton;
 
 Now we can dynamically style our components for the theme.
 
-Lastly let's change `PrimaryButton to also be a named export. This way we can import it as the default component or explicitly with a named import`{ PrimaryButtton }`.
+Lastly let's change `PrimaryButton` to also be a named export. This way we can import it as the default component or explicitly with a named import `{ PrimaryButtton }`.
 
 If you toggle the state you should see our theme working! You may also find some bugs during the theme toggle but you can fix those later.
 


### PR DESCRIPTION
Adds a missing backtick to fix this visual bug:

<img width="835" alt="Screenshot 2020-02-24 at 15 04 12" src="https://user-images.githubusercontent.com/7525670/75199068-f9cbc700-5716-11ea-9171-30a82d45dc47.png">