### PR TITLE
fix(a11y): add htmlFor to text fields

### DIFF
--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -34,7 +34,7 @@ const ModalHeader = styled.h3`
 `;
 
 const SignUpText = styled.p`
-  font-size:: ${typeScale.paragraph};
+  font-size: ${typeScale.paragraph};
   max-width: 70%;
   text-align: center;
 `;

--- a/src/components/TextFields.js
+++ b/src/components/TextFields.js
@@ -20,14 +20,14 @@ const Label = styled.label`
 
 export const EmailInput = ({ label, placeholder }) => (
   <div style={{ display: "flex", flexDirection: "column", marginTop: "16px" }}>
-    <Label>{label}</Label>
-    <Input type="email" placeholder={placeholder} />
+    <Label htmlFor="email">{label}</Label>
+    <Input id="email" type="email" placeholder={placeholder} />
   </div>
 );
 
 export const PasswordInput = ({ label, placeholder }) => (
   <div style={{ display: "flex", flexDirection: "column", marginTop: "16px" }}>
-    <Label>{label}</Label>
-    <Input type="password" />
+    <Label htmlFor="password">{label}</Label>
+    <Input id="password" type="password" placeholder={placeholder} />
   </div>
 );


### PR DESCRIPTION
This PR:
- Adds the `htmlFor` attribute to the text fields.
- Fixes a typo in a styled component.