### PR TITLE
[WIP] refactor: remove storiesOf section

### DIFF
--- a/docs/documenting-components-with-storybook.md
+++ b/docs/documenting-components-with-storybook.md
@@ -119,6 +119,10 @@ Addons are neat packages you can install and use with Storybook to gain addition
 We can also use the `action` function from `storybook/addon-actions` to dispatch actions when our button is clicked. This will simply log the event in the Storybook console.
 
 ```jsx
+
+// Add a new import
+import { action } from "@storybook/addon-actions";
+
 export const Primary = () => (
   <Theme>
     <PrimaryButton onClick={action("click")}>Primary button</PrimaryButton>


### PR DESCRIPTION
First pass on removing the `storiesOf ` section in storybook.

### Reason
The CSF (component story format) is the recommended way to develop stories per the storybook team.  Also, this would open up more time for other topics/activities.

* Because the docs are a jekyll site, I'm not sure how I can preview the docs beyond looking at the markdown, so I'm hoping to get some more eyes on this to make sure I got it all.

### Other Affected Items
I also noticed that the first step was to have the class do the following:

```jsx
Inside Button.stories.js change the content to the following:

import React from "react";
import { action } from "@storybook/addon-actions";
import {
  PrimaryButton,
  SecondaryButton,
  TertiaryButton
} from "../components/Buttons";

export default {
  title: "Buttons"
};

export const Primary = () => (
  <PrimaryButton onClick={action("clicked")}>Primary Button</PrimaryButton>
);

...
```
Because actions are covered later on in this section, I also removed the `onClick={action("clicked")}`  parts and later added them back in the section discussing addons. 


Happy to make any changes based on feedback 👍 