### PR TITLE
Styled components example consistency

### DIFF
--- a/docs/developing-styled-components.md
+++ b/docs/developing-styled-components.md
@@ -745,28 +745,28 @@ const BUTTON_MODIFIERS = {
     }
   `,
   error: () => `
-  background-color: ${defaultTheme.errorColor};
-  color: ${defaultTheme.textColorInverted};
+    background-color: ${defaultTheme.errorColor};
+    color: ${defaultTheme.textColorInverted};
 
-  &:hover {
-    background-color: ${defaultTheme.errorColorHover};
-  }
+    &:hover {
+      background-color: ${defaultTheme.errorColorHover};
+    }
 
-  &:active {
-    background-color: ${defaultTheme.errorColorActive};
-  }
+    &:active {
+      background-color: ${defaultTheme.errorColorActive};
+    }
   `,
   success: () => `
-  background-color: ${defaultTheme.successColor};
-  color: ${defaultTheme.textColorInverted};
+    background-color: ${defaultTheme.successColor};
+    color: ${defaultTheme.textColorInverted};
 
-  &:hover {
-    background-color: ${defaultTheme.successColorHover};
-  }
+    &:hover {
+      background-color: ${defaultTheme.successColorHover};
+    }
 
-  &:active {
-    background-color: ${defaultTheme.successColorActive};
-  }
+    &:active {
+      background-color: ${defaultTheme.successColorActive};
+    }
   `
 };
 ```


### PR DESCRIPTION
This PR requests a couple changes

- Before the theme usage was introduced, there were a couple examples with colors being pulled from props instead of the default theme which was a little confusing.

- When building the BUTTON_MODIFIERS object after themes were introduced, most of the colors were coming from the destructed `theme`, but there were a couple examples that were pulling the colors off of props. I'm not sure if this was intended, but I found it a little confusing. I don't have any experience with modifiers and I was unsure if the two methods were separate concepts being introduced or two ways to do the same thing.

- Some of the modifiers code was missing indentation
 